### PR TITLE
Do not quit Hartigan-Wong prematurely when quick_transfer does not converge.

### DIFF
--- a/include/kmeans/RefineHartiganWong.hpp
+++ b/include/kmeans/RefineHartiganWong.hpp
@@ -518,7 +518,7 @@ std::pair<bool, bool> quick_transfer(
  * 
  * In the `Details::status` returned by `run()`, the status code is either 0 (success),
  * 2 (maximum optimal transfer iterations reached without convergence)
- * or 4 (maximum quick transfer iterations reached without convergence, if `RefineHartiganWongOptions::quit_on_quick_transfer_convergence_failure = false`).
+ * or 4 (maximum quick transfer iterations reached without convergence, if `RefineHartiganWongOptions::quit_on_quick_transfer_convergence_failure = true`).
  * Previous versions of the library would report a status code of 1 upon encountering an empty cluster, but these are now just ignored.
  * 
  * @tparam Matrix_ Matrix type for the input data.
@@ -608,7 +608,7 @@ public:
                 }
             }
 
-            if (quick_status.first) { // At least one transfer was performed.
+            if (quick_status.first) { // At least one quick transfer was performed.
                 work.optra_steps_since_last_transfer = 0;
             }
 

--- a/tests/R/src/hartigan_wong.cpp
+++ b/tests/R/src/hartigan_wong.cpp
@@ -7,6 +7,7 @@ Rcpp::List hartigan_wong(Rcpp::NumericMatrix x, Rcpp::NumericMatrix init) {
     Rcpp::IntegerVector clusters(x.ncol());
 
     kmeans::RefineHartiganWong hw;
+    hw.get_options().quit_on_quick_transfer_convergence_failure = true;
     kmeans::SimpleMatrix<double, int> mat(x.nrow(), x.ncol(), x.begin());
     auto res = hw.run(mat, output.ncol(), output.begin(), clusters.begin());
 

--- a/tests/src/RefineHartiganWong.cpp
+++ b/tests/src/RefineHartiganWong.cpp
@@ -49,6 +49,25 @@ TEST_P(RefineHartiganWongBasicTest, Sweep) {
         EXPECT_EQ(clusters2, clusters);
     }
 
+    // Checking we get sensible results if we don't do any quick transfers at all.
+    {
+        kmeans::RefineHartiganWong hw2;
+        hw2.get_options().max_quick_transfer_iterations = 0;
+
+        auto centers2 = original;
+        std::vector<int> clusters2(nc);
+        auto res2 = hw2.run(mat, ncenters, centers2.data(), clusters2.data());
+        EXPECT_EQ(res.status, 0);
+
+        std::vector<int> counts(ncenters);
+        for (auto c : clusters2) {
+            EXPECT_TRUE(c >= 0 && c < ncenters);
+            ++counts[c];
+        }
+        EXPECT_EQ(counts, res2.sizes);
+        EXPECT_TRUE(res2.iterations > 0);
+    }
+
     // Checking paralleization yields the same results.
     {
         kmeans::RefineHartiganWongOptions popt;

--- a/tests/src/RefineHartiganWong.cpp
+++ b/tests/src/RefineHartiganWong.cpp
@@ -24,6 +24,7 @@ TEST_P(RefineHartiganWongBasicTest, Sweep) {
 
     kmeans::RefineHartiganWong hw;
     auto res = hw.run(mat, ncenters, centers.data(), clusters.data());
+    EXPECT_EQ(res.status, 0);
 
     // Checking that there's the specified number of clusters. 
     std::vector<int> counts(ncenters);
@@ -33,6 +34,20 @@ TEST_P(RefineHartiganWongBasicTest, Sweep) {
     }
     EXPECT_EQ(counts, res.sizes);
     EXPECT_TRUE(res.iterations > 0);
+
+    // Checking we don't get held up by quick transfer convergence failures.
+    {
+        kmeans::RefineHartiganWong hw2;
+        hw2.get_options().quit_on_quick_transfer_convergence_failure = true;
+
+        auto centers2 = original;
+        std::vector<int> clusters2(nc);
+        auto res2 = hw2.run(mat, ncenters, centers2.data(), clusters2.data());
+        EXPECT_EQ(res.status, 0);
+
+        EXPECT_EQ(centers2, centers);
+        EXPECT_EQ(clusters2, clusters);
+    }
 
     // Checking paralleization yields the same results.
     {
@@ -96,6 +111,31 @@ TEST_F(RefineHartiganWongConstantTest, Extremes) {
         auto res0 = hw.run(mat, 0, NULL, NULL);
         EXPECT_TRUE(res0.sizes.empty());
     }
+}
+
+TEST_F(RefineHartiganWongConstantTest, OptimalTransferFailure) {
+    kmeans::SimpleMatrix mat(nr, nc, data.data());
+    kmeans::RefineHartiganWong hw;
+    hw.get_options().max_iterations = 0;
+
+    int ncenters = 3;
+    auto centers = create_centers(ncenters);
+    std::vector<int> clusters(nc);
+    auto res = hw.run(mat, ncenters, centers.data(), clusters.data());
+    EXPECT_EQ(res.status, 2);
+}
+
+TEST_F(RefineHartiganWongConstantTest, QuickTransferFailure) {
+    kmeans::SimpleMatrix mat(nr, nc, data.data());
+    kmeans::RefineHartiganWong hw;
+    hw.get_options().quit_on_quick_transfer_convergence_failure = true;
+    hw.get_options().max_quick_transfer_iterations = 0;
+
+    int ncenters = 3;
+    auto centers = create_centers(ncenters);
+    std::vector<int> clusters(nc);
+    auto res = hw.run(mat, ncenters, centers.data(), clusters.data());
+    EXPECT_EQ(res.status, 4);
 }
 
 TEST(RefineHartiganWong, Options) {


### PR DESCRIPTION
…nverge.

This gives the opportunity for the algorithm to improve by performing more optimal transfers. Users can restore the previous behavior (equivalent to stats::kmeans) with an option. We also add another option to modify the number of quick_transfer iterations, mostly for testing purposes.